### PR TITLE
Support different destination datasets based on event key

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ Parameter | Type | Required? | Description
 | `sample_rate` | integer | no | Sample your event stream by sending 1 out of every N events. |
 | `include_tag_key` | bool | no | Whether to include the Fluentd tag in the submitted event. |
 | `tag_key` | string | no | If `include_tag_key` is `true`, the tag key name in the event (default: `fluentd_tag`).
-| `flatten_keys` | array | no | Flatten nested JSON data under these keys into
-the top-level event.
-
+| `flatten_keys` | array | no | Flatten nested JSON data under these keys into the top-level event.
+| `dataset_from_key` | string | no | Look for this key in each event, and use its value as the destination dataset. If an event doesn't contain the key, it'll be sent to the dataset given by the `dataset` parameter.
 
 ### Buffering options
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,13 @@ A note about naming: This gem must be named `fluent-plugin-xxx` in order to auto
 
 ## Releasing a new version
 Travis will automatically upload tagged releases to Rubygems. To release a new
-version, run
-```
-bump patch --tag   # Or bump minor --tag, etc.
-git push --follow-tags
-```
+version:
+
+1. Update the value of `HONEYCOMB_PLUGIN_VERSION` in
+   lib/plugin/out_honeycomb_version.rb`
+
+2. Run
+    ```
+    bump patch --tag   # Or bump minor --tag, etc.
+    git push --follow-tags
+    ```

--- a/lib/fluent/plugin/out_honeycomb.rb
+++ b/lib/fluent/plugin/out_honeycomb.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'http'
 require 'fluent/output'
+require_relative 'out_honeycomb_version'
 
 module Fluent
   class HoneycombOutput < BufferedOutput
@@ -100,7 +101,7 @@ module Fluent
       log.info "publishing #{batch.length} records to dataset #{dataset}"
       body = JSON.dump(batch)
       resp = HTTP.headers(
-          "User-Agent" => "fluent-plugin-honeycomb",
+          "User-Agent" => "fluent-plugin-honeycomb/#{HONEYCOMB_PLUGIN_VERSION}",
           "Content-Type" => "application/json",
           "X-Honeycomb-Team" => @writekey)
           .post(URI.join(@api_host, "/1/batch/#{dataset}"), {

--- a/lib/fluent/plugin/out_honeycomb_version.rb
+++ b/lib/fluent/plugin/out_honeycomb_version.rb
@@ -1,0 +1,2 @@
+# Don't just call this VERSION, conflicts with global fluentd version constant
+HONEYCOMB_PLUGIN_VERSION = "0.4.2"


### PR DESCRIPTION
Address the request in #5 to send events to different datasets based on
the value of a particular key within the event. 