### PR TITLE
Correct sample_rate logic to send 1/rate events instead of (rate - 1)/rate events

### DIFF
--- a/fluent-plugin-honeycomb.gemspec
+++ b/fluent-plugin-honeycomb.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "webmock", "~> 2.1"
   spec.add_development_dependency "test-unit"
+  spec.add_development_dependency "mocha"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "bump"

--- a/lib/fluent/plugin/out_honeycomb.rb
+++ b/lib/fluent/plugin/out_honeycomb.rb
@@ -63,7 +63,7 @@ module Fluent
           log.debug "Skipping record #{record}"
           next
         end
-        if @sample_rate > 1 && rand(1..@sample_rate) == 1
+        if @sample_rate > 1 && rand(1..@sample_rate) > 1
           next
         end
         if @include_tag_key

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,6 +8,7 @@ end
 
 require 'test/unit'
 require 'fluent/test'
+require "mocha/test_unit"
 
 require 'webmock/test_unit'
 WebMock.disable_net_connect!


### PR DESCRIPTION
Based on my understanding of the documentation, it seems like there's an error in the code related to `sample_rate`. As previously written, the code would only skip randomly one out of every `sample_rate` times, instead of randomly `sample_rate` less one. As in, if your sample rate was 4, the code would send events when `rand(1..4)` generated 2, 3, or 4.

This would change the logic to send events only when `rand(1..4)` generates 1.

The majority of this PR is adding the mocha mocking framework to better test the `sample_rate` code. I had a version that monkey patched `Kernel.rand` to achieve the same result, but that seemed overall worse and resulted in warnings when running the tests.