### PR TITLE
Add presampled_key option for events that have been sampled before getting to fluent

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Parameter | Type | Required? | Description
 | `tag_key` | string | no | If `include_tag_key` is `true`, the tag key name in the event (default: `fluentd_tag`).
 | `flatten_keys` | array | no | Flatten nested JSON data under these keys into the top-level event.
 | `dataset_from_key` | string | no | Look for this key in each event, and use its value as the destination dataset. If an event doesn't contain the key, it'll be sent to the dataset given by the `dataset` parameter.
-| `presampled_key` | string | no | Look for this key in each event, and use its value as the sample rate for the record. If an event doesn't contain the key, the logic around `sample_rate` will be used (1 out of every N events will be sent instead). |
+| `presampled_key` | string | no | Look for this key in each event, and use its value as the sample rate for the record. If an event doesn't contain the key, the logic around `sample_rate` will be used (1 out of every N events will be sent instead). If an event's `presampled_key` value is not a positive integer, the value is discarded, and the event is sent to Honeycomb with a `samplerate` of 1 (the default), ignoring the `sample_rate` configuration option. |
 
 ### Buffering options
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Parameter | Type | Required? | Description
 | `tag_key` | string | no | If `include_tag_key` is `true`, the tag key name in the event (default: `fluentd_tag`).
 | `flatten_keys` | array | no | Flatten nested JSON data under these keys into the top-level event.
 | `dataset_from_key` | string | no | Look for this key in each event, and use its value as the destination dataset. If an event doesn't contain the key, it'll be sent to the dataset given by the `dataset` parameter.
+| `presampled_key` | string | no | Look for this key in each event, and use its value as the sample rate for the record. If an event doesn't contain the key, the logic around `sample_rate` will be used (1 out of every N events will be sent instead). |
 
 ### Buffering options
 

--- a/lib/fluent/plugin/out_honeycomb.rb
+++ b/lib/fluent/plugin/out_honeycomb.rb
@@ -67,6 +67,12 @@ module Fluent
 
         if @presampled_key && record.include?(@presampled_key)
           sample_rate = record.delete(@presampled_key)
+
+          if !sample_rate.is_a?(Integer) || sample_rate < 1
+            log.warn "Record emitted a presampled key (#{@presampled_key} = #{sample_rate}), but was not a valid sample rate #{record}"
+
+            sample_rate = 1
+          end
         else
           sample_rate = @sample_rate
 

--- a/test/out_honeycomb_test.rb
+++ b/test/out_honeycomb_test.rb
@@ -279,4 +279,35 @@ class HoneycombOutput < Test::Unit::TestCase
 
     send_helper(extra_opts, inputs, request_bodies)
   end
+
+  def test_presampled_key_with_sample_rate
+    Fluent::HoneycombOutput.any_instance.expects(:rand)
+      .at_least(4)
+      .returns(1, 2, 1, 2)
+
+    extra_opts = %{
+      presampled_key sample_rate
+      sample_rate 2
+    }
+
+    inputs = [
+      {"a" => 1, "sample_rate" => 7},
+      {"a" => 2},
+      {"a" => 3, "sample_rate" => 4},
+      {"a" => 4},
+      {"a" => 5},
+      {"a" => 6, "sample_rate" => 9},
+      {"a" => 7},
+    ]
+
+    request_bodies = {"testdataset" => [
+      {"data" => {"a" => 1}, "samplerate" => 7, "time" => "2006-01-02T15:04:05+00:00"},
+      {"data" => {"a" => 2}, "samplerate" => 2, "time" => "2006-01-02T15:04:05+00:00"},
+      {"data" => {"a" => 3}, "samplerate" => 4, "time" => "2006-01-02T15:04:05+00:00"},
+      {"data" => {"a" => 5}, "samplerate" => 2, "time" => "2006-01-02T15:04:05+00:00"},
+      {"data" => {"a" => 6}, "samplerate" => 9, "time" => "2006-01-02T15:04:05+00:00"},
+    ]}
+
+    send_helper(extra_opts, inputs, request_bodies)
+  end
 end

--- a/test/out_honeycomb_test.rb
+++ b/test/out_honeycomb_test.rb
@@ -257,4 +257,26 @@ class HoneycombOutput < Test::Unit::TestCase
 
     send_helper(extra_opts, inputs, request_bodies)
   end
+
+  def test_presampled_key
+    extra_opts = %{presampled_key sample_rate}
+
+    inputs = [
+      {"a" => 1, "sample_rate" => 10},
+      {"a" => 2, "sample_rate" => 4},
+      {"a" => 3},
+      {"a" => 4, "sample_rate" => 2},
+      {"a" => 5},
+    ]
+
+    request_bodies = {"testdataset" => [
+      {"data" => {"a" => 1}, "samplerate" => 10, "time" => "2006-01-02T15:04:05+00:00"},
+      {"data" => {"a" => 2}, "samplerate" => 4, "time" => "2006-01-02T15:04:05+00:00"},
+      {"data" => {"a" => 3}, "samplerate" => 1, "time" => "2006-01-02T15:04:05+00:00"},
+      {"data" => {"a" => 4}, "samplerate" => 2, "time" => "2006-01-02T15:04:05+00:00"},
+      {"data" => {"a" => 5}, "samplerate" => 1, "time" => "2006-01-02T15:04:05+00:00"},
+    ]}
+
+    send_helper(extra_opts, inputs, request_bodies)
+  end
 end

--- a/test/out_honeycomb_test.rb
+++ b/test/out_honeycomb_test.rb
@@ -310,4 +310,37 @@ class HoneycombOutput < Test::Unit::TestCase
 
     send_helper(extra_opts, inputs, request_bodies)
   end
+
+  def test_presampled_key_bad_value
+    extra_opts = %{
+      presampled_key sample_rate
+      sample_rate 2
+    }
+
+    Fluent::HoneycombOutput.any_instance.expects(:rand)
+      .once
+      .returns(1)
+
+    inputs = [
+      {"a" => 1, "sample_rate" => 8},
+      {"a" => 2, "sample_rate" => "foo"},
+      {"a" => 3, "sample_rate" => -3},
+      {"a" => 4, "sample_rate" => 4.8},
+      {"a" => 5, "sample_rate" => nil},
+      {"a" => 6, "sample_rate" => []},
+      {"a" => 7},
+    ]
+
+    request_bodies = {"testdataset" => [
+      {"data" => {"a" => 1}, "samplerate" => 8, "time" => "2006-01-02T15:04:05+00:00"},
+      {"data" => {"a" => 2}, "samplerate" => 1, "time" => "2006-01-02T15:04:05+00:00"},
+      {"data" => {"a" => 3}, "samplerate" => 1, "time" => "2006-01-02T15:04:05+00:00"},
+      {"data" => {"a" => 4}, "samplerate" => 1, "time" => "2006-01-02T15:04:05+00:00"},
+      {"data" => {"a" => 5}, "samplerate" => 1, "time" => "2006-01-02T15:04:05+00:00"},
+      {"data" => {"a" => 6}, "samplerate" => 1, "time" => "2006-01-02T15:04:05+00:00"},
+      {"data" => {"a" => 7}, "samplerate" => 2, "time" => "2006-01-02T15:04:05+00:00"},
+    ]}
+
+    send_helper(extra_opts, inputs, request_bodies)
+  end
 end


### PR DESCRIPTION
Problem: we have some applications which are doing sampling internally, and want to forward those records along to honeycomb, with the correct sampling rate.

This addition allows users to set an optional `presampled_key` in their configuration, which will be used as the `samplerate` sent to Honeycomb. If an event doesn't include the `presampled_key`, the existing logic is still used (all events sent with `samplerate` 1, or N events are sent with whatever `sample_rate` is set to).