### PR TITLE
Change required_ruby_version to 2.0.0

### DIFF
--- a/fluent-plugin-honeycomb.gemspec
+++ b/fluent-plugin-honeycomb.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_runtime_dependency "fluentd", "~> 0.12"
   spec.add_runtime_dependency "http", "< 3"


### PR DESCRIPTION
fluentd bundled in https://github.com/openshift/origin-aggregated-logging is on Ruby 2.0.0

If there are compatibility issues with the existing code, we'll fix them as they come along.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>