### PR TITLE
Retry rather than raise exception when batch fails

### DIFF
--- a/lib/fluent/plugin/out_honeycomb.rb
+++ b/lib/fluent/plugin/out_honeycomb.rb
@@ -132,9 +132,9 @@ module Fluent
 
     def parse_response(batch, resp)
       if resp.status != 200
-        # Force retry
         log.error "Error sending batch: #{resp.status}, #{resp.body}"
-        raise Exception.new("Error sending batch: #{resp.status}, #{resp.body}")
+        # Force retry by returning the entire batch
+        return batch
       end
 
       begin

--- a/lib/fluent/plugin/out_honeycomb_version.rb
+++ b/lib/fluent/plugin/out_honeycomb_version.rb
@@ -1,2 +1,2 @@
 # Don't just call this VERSION, conflicts with global fluentd version constant
-HONEYCOMB_PLUGIN_VERSION = "0.7.0"
+HONEYCOMB_PLUGIN_VERSION = "0.7.1"


### PR DESCRIPTION
When a non-200 error is returned by our batch endpoint, we raise an exception. I don't know what the original reason was for raising an exception here, but currently it causes the plugin to exit abnormally. Instead, we should return the entire batch, which will result in a retry of all events in the batch.

Fixes https://github.com/honeycombio/fluent-plugin-honeycomb/issues/15