### PR TITLE
JSON parse expects a string, not a HTTP Response object

### DIFF
--- a/lib/fluent/plugin/out_honeycomb.rb
+++ b/lib/fluent/plugin/out_honeycomb.rb
@@ -138,7 +138,7 @@ module Fluent
       end
 
       begin
-        results = JSON.parse(resp.body)
+        results = JSON.parse(resp.body.to_s)
       rescue JSON::ParserError => e
         log.warn "Error parsing response as JSON: #{e}"
         raise e


### PR DESCRIPTION
Taking the suggestion from #19 this changes the handling of the response received from trying to parse the entire response object to specifically accepting the response body as a string.

Test plan: try out the new gem in a fluent setup, verify it works